### PR TITLE
Introduce option to scrape all connection agents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DOCKER_PREFIX=mspreitz
 DOCKER_TAG=01cd6de7d18b6157b241888ba98d2ced22bce2a2
 KOS_PERSIST=${HOME}/.kos-perf-study
+SMALL=false
 
 clean:
 	rm -f deploy/main/[57]0-*
@@ -111,7 +112,7 @@ deploy/main/50-d-xs.yaml: deploy.m4/main/50-d-xs.yaml.m4
 	m4 -DDOCKER_PREFIX=${DOCKER_PREFIX} -DDOCKER_TAG=${DOCKER_TAG} deploy.m4/main/50-d-xs.yaml.m4 > deploy/main/50-d-xs.yaml
 
 deploy/main/50-ds-ca.yaml: deploy.m4/main/50-ds-ca.yaml.m4
-	m4 -DDOCKER_PREFIX=${DOCKER_PREFIX} -DDOCKER_TAG=${DOCKER_TAG} deploy.m4/main/50-ds-ca.yaml.m4 > deploy/main/50-ds-ca.yaml
+	m4 -DDOCKER_PREFIX=${DOCKER_PREFIX} -DDOCKER_TAG=${DOCKER_TAG} -DSMALL=${SMALL} deploy.m4/main/50-ds-ca.yaml.m4 > deploy/main/50-ds-ca.yaml
 
 deploy/main/50-d-kcm.yaml: deploy.m4/main/50-d-kcm.yaml.m4
 	m4 -DDOCKER_PREFIX=${DOCKER_PREFIX} -DDOCKER_TAG=${DOCKER_TAG} deploy.m4/main/50-d-kcm.yaml.m4 > deploy/main/50-d-kcm.yaml

--- a/deploy.m4/main/50-ds-ca.yaml.m4
+++ b/deploy.m4/main/50-ds-ca.yaml.m4
@@ -12,7 +12,7 @@ spec:
       labels:
         kos-app: connection-agent
       annotations:
-        prometheus.io/sample: "true"
+        prometheus.io/ifelse(SMALL,true,scrape,sample): "true"
         prometheus.io/port: "9294"
     spec:
       serviceAccountName: connection-agent


### PR DESCRIPTION
`make deploy SMALL=true` will now annotate the connection agent pods for scraping by Prometheus.  The alternative, which is the default behavior, is that the connection agent pods are annotated so that only a few of them are scraped.