### PR TITLE
Add dashboards on delay due to controllers downtime

### DIFF
--- a/metrics/grafana/dashboard-defs/kos-externals.json
+++ b/metrics/grafana/dashboard-defs/kos-externals.json
@@ -123,12 +123,112 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "description": "The absolute number of subnets that were affected is scaled down by 100 to make it closer to the other plots and make sure the real values are not approximated.",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "kos_subnet_validator_validation_delay_due_to_downtime_seconds_count / 100",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "num waiters / 100 statusErr={{ statusErr }}",
+          "refId": "A"
+        },
+        {
+          "expr": "kos_subnet_validator_validation_delay_due_to_downtime_seconds_count / kos_subnet_validator_subnet_create_to_validated_latency_seconds_count",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "waiters / total statusErr={{ statusErr }}",
+          "refId": "B"
+        },
+        {
+          "expr": "kos_subnet_validator_validation_delay_due_to_downtime_seconds_sum / kos_subnet_validator_validation_delay_due_to_downtime_seconds_count",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "avg wait secs statusErr={{ statusErr }}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subnet Validation Delay due to Validator Downtime",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 16
       },
       "id": 2,
       "legend": {
@@ -215,13 +315,114 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "description": "The absolute number of attachments that were affected is scaled down by 100 to make it closer to the other plots and make sure the real values are not approximated.",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 17,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "kos_ipam_address_delay_due_to_downtime_seconds_count / 100",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "num waiters / 100 last_client_wr={{ last_client_wr }} last_controller_start={{ last_controller_start }}",
+          "refId": "A"
+        },
+        {
+          "expr": "kos_ipam_address_delay_due_to_downtime_seconds_count / scalar(sum(kos_ipam_last_client_write_to_address_latency_seconds_count))",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "waiters / total last_client_wr={{ last_client_wr }} last_controller_start={{ last_controller_start }}",
+          "refId": "B"
+        },
+        {
+          "expr": "kos_ipam_address_delay_due_to_downtime_seconds_sum / kos_ipam_address_delay_due_to_downtime_seconds_count",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "avg delay secs last_client_wr={{ last_client_wr }} last_controller_start={{ last_controller_start }}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Address Assignment Delay due to Controllers Downtime",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
       "description": "Fraction of attempt to allocate an address that fail because none is available",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 30
       },
       "id": 12,
       "legend": {
@@ -306,7 +507,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 37
       },
       "id": 1,
       "legend": {
@@ -387,12 +588,113 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "description": "The absolute number of attachments that were affected is scaled down by 100 to make it closer to the other plots and make sure the real values are not approximated.",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 44
+      },
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "kos_agent_local_ifc_delay_due_to_downtime_seconds_count / 100",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "num waiters / 100 {{ node_name }} last_client_wr={{ last_client_wr }}",
+          "refId": "A"
+        },
+        {
+          "expr": "kos_agent_local_ifc_delay_due_to_downtime_seconds_count / on(node_name) group_left sum(kos_agent_last_client_write_to_local_ifc_latency_seconds_count) by (node_name)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "waiters / total {{ node_name }} last_client_wr={{ last_client_wr }}",
+          "refId": "B"
+        },
+        {
+          "expr": "kos_agent_local_ifc_delay_due_to_downtime_seconds_count / kos_agent_local_ifc_delay_due_to_downtime_seconds_sum",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "avg delay secs {{ node_name }} last_client_wr={{ last_client_wr }}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Local Interface Creation Delay due to CA Downtime",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 51
       },
       "id": 4,
       "legend": {
@@ -477,7 +779,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 58
       },
       "id": 13,
       "legend": {
@@ -557,12 +859,112 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "description": "The absolute number of attachments that were affected is scaled down by 100 to make it closer to the other plots and make sure the real values are not approximated.",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 65
+      },
+      "id": 19,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "kos_agent_remote_ifc_delay_due_to_downtime_seconds_count / 100",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "num waiters / 100 {{ node_name }} last_ca_start={{ last_ca_start }} last_client_wr={{ last_client_wr }}",
+          "refId": "A"
+        },
+        {
+          "expr": "kos_agent_remote_ifc_delay_due_to_downtime_seconds_count / on(node_name) group_left sum(kos_agent_last_client_write_to_remote_ifc_latency_seconds_count) by (node_name)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "waiters / total {{ node_name }} last_ca_start={{ last_ca_start }} last_client_wr={{ last_client_wr }}",
+          "refId": "B"
+        },
+        {
+          "expr": "kos_agent_remote_ifc_delay_due_to_downtime_seconds_sum / kos_agent_remote_ifc_delay_due_to_downtime_seconds_count",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "avg delay secs {{ node_name }} last_ca_start={{ last_ca_start }} last_client_wr={{ last_client_wr }}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Remote Interface Creation Delay due to local or remote CA Downtime",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 72
       },
       "id": 14,
       "legend": {
@@ -648,7 +1050,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 79
       },
       "id": 15,
       "legend": {
@@ -733,7 +1135,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 86
       },
       "id": 9,
       "legend": {
@@ -818,7 +1220,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 64
+        "y": 93
       },
       "id": 8,
       "legend": {
@@ -903,7 +1305,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 71
+        "y": 100
       },
       "id": 7,
       "legend": {

--- a/metrics/grafana/dashboard-defs/kos-externals.json
+++ b/metrics/grafana/dashboard-defs/kos-externals.json
@@ -620,7 +620,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kos_agent_local_ifc_delay_due_to_downtime_seconds_count / 100",
+          "expr": "kos_agent_local_ifc_delay_due_to_local_ca_downtime_seconds_count / 100",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -628,14 +628,14 @@
           "refId": "A"
         },
         {
-          "expr": "kos_agent_local_ifc_delay_due_to_downtime_seconds_count / on(node_name) group_left sum(kos_agent_last_client_write_to_local_ifc_latency_seconds_count) by (node_name)",
+          "expr": "kos_agent_local_ifc_delay_due_to_local_ca_downtime_seconds_count / on(node_name) group_left sum(kos_agent_last_client_write_to_local_ifc_latency_seconds_count) by (node_name)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "waiters / total {{ node_name }} last_client_wr={{ last_client_wr }}",
           "refId": "B"
         },
         {
-          "expr": "kos_agent_local_ifc_delay_due_to_downtime_seconds_count / kos_agent_local_ifc_delay_due_to_downtime_seconds_sum",
+          "expr": "kos_agent_local_ifc_delay_due_to_local_ca_downtime_seconds_count / kos_agent_local_ifc_delay_due_to_local_ca_downtime_seconds_sum",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "avg delay secs {{ node_name }} last_client_wr={{ last_client_wr }}",
@@ -891,21 +891,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kos_agent_remote_ifc_delay_due_to_downtime_seconds_count / 100",
+          "expr": "kos_agent_remote_ifc_delay_due_to_remote_ca_downtime_seconds_count / 100",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "num waiters / 100 {{ node_name }} last_ca_start={{ last_ca_start }} last_client_wr={{ last_client_wr }}",
           "refId": "A"
         },
         {
-          "expr": "kos_agent_remote_ifc_delay_due_to_downtime_seconds_count / on(node_name) group_left sum(kos_agent_last_client_write_to_remote_ifc_latency_seconds_count) by (node_name)",
+          "expr": "kos_agent_remote_ifc_delay_due_to_remote_ca_downtime_seconds_count / on(node_name) group_left sum(kos_agent_last_client_write_to_remote_ifc_latency_seconds_count) by (node_name)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "waiters / total {{ node_name }} last_ca_start={{ last_ca_start }} last_client_wr={{ last_client_wr }}",
           "refId": "B"
         },
         {
-          "expr": "kos_agent_remote_ifc_delay_due_to_downtime_seconds_sum / kos_agent_remote_ifc_delay_due_to_downtime_seconds_count",
+          "expr": "kos_agent_remote_ifc_delay_due_to_remote_ca_downtime_seconds_sum / kos_agent_remote_ifc_delay_due_to_remote_ca_downtime_seconds_count",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "avg delay secs {{ node_name }} last_ca_start={{ last_ca_start }} last_client_wr={{ last_client_wr }}",
@@ -916,7 +916,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Remote Interface Creation Delay due to local or remote CA Downtime",
+      "title": "Remote Interface Creation Delay due to Remote CA Downtime",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/metrics/grafana/manifests/configmap-dashboard-defs.yaml
+++ b/metrics/grafana/manifests/configmap-dashboard-defs.yaml
@@ -4978,7 +4978,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "kos_agent_local_ifc_delay_due_to_downtime_seconds_count / 100",
+              "expr": "kos_agent_local_ifc_delay_due_to_local_ca_downtime_seconds_count / 100",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -4986,14 +4986,14 @@ data:
               "refId": "A"
             },
             {
-              "expr": "kos_agent_local_ifc_delay_due_to_downtime_seconds_count / on(node_name) group_left sum(kos_agent_last_client_write_to_local_ifc_latency_seconds_count) by (node_name)",
+              "expr": "kos_agent_local_ifc_delay_due_to_local_ca_downtime_seconds_count / on(node_name) group_left sum(kos_agent_last_client_write_to_local_ifc_latency_seconds_count) by (node_name)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "waiters / total {{ node_name }} last_client_wr={{ last_client_wr }}",
               "refId": "B"
             },
             {
-              "expr": "kos_agent_local_ifc_delay_due_to_downtime_seconds_count / kos_agent_local_ifc_delay_due_to_downtime_seconds_sum",
+              "expr": "kos_agent_local_ifc_delay_due_to_local_ca_downtime_seconds_count / kos_agent_local_ifc_delay_due_to_local_ca_downtime_seconds_sum",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "avg delay secs {{ node_name }} last_client_wr={{ last_client_wr }}",
@@ -5249,21 +5249,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "kos_agent_remote_ifc_delay_due_to_downtime_seconds_count / 100",
+              "expr": "kos_agent_remote_ifc_delay_due_to_remote_ca_downtime_seconds_count / 100",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "num waiters / 100 {{ node_name }} last_ca_start={{ last_ca_start }} last_client_wr={{ last_client_wr }}",
               "refId": "A"
             },
             {
-              "expr": "kos_agent_remote_ifc_delay_due_to_downtime_seconds_count / on(node_name) group_left sum(kos_agent_last_client_write_to_remote_ifc_latency_seconds_count) by (node_name)",
+              "expr": "kos_agent_remote_ifc_delay_due_to_remote_ca_downtime_seconds_count / on(node_name) group_left sum(kos_agent_last_client_write_to_remote_ifc_latency_seconds_count) by (node_name)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "waiters / total {{ node_name }} last_ca_start={{ last_ca_start }} last_client_wr={{ last_client_wr }}",
               "refId": "B"
             },
             {
-              "expr": "kos_agent_remote_ifc_delay_due_to_downtime_seconds_sum / kos_agent_remote_ifc_delay_due_to_downtime_seconds_count",
+              "expr": "kos_agent_remote_ifc_delay_due_to_remote_ca_downtime_seconds_sum / kos_agent_remote_ifc_delay_due_to_remote_ca_downtime_seconds_count",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "avg delay secs {{ node_name }} last_ca_start={{ last_ca_start }} last_client_wr={{ last_client_wr }}",
@@ -5274,7 +5274,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Remote Interface Creation Delay due to local or remote CA Downtime",
+          "title": "Remote Interface Creation Delay due to Remote CA Downtime",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/metrics/grafana/manifests/configmap-dashboard-defs.yaml
+++ b/metrics/grafana/manifests/configmap-dashboard-defs.yaml
@@ -4481,12 +4481,112 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
+          "description": "The absolute number of subnets that were affected is scaled down by 100 to make it closer to the other plots and make sure the real values are not approximated.",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 8
+          },
+          "id": 16,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "kos_subnet_validator_validation_delay_due_to_downtime_seconds_count / 100",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "num waiters / 100 statusErr={{ statusErr }}",
+              "refId": "A"
+            },
+            {
+              "expr": "kos_subnet_validator_validation_delay_due_to_downtime_seconds_count / kos_subnet_validator_subnet_create_to_validated_latency_seconds_count",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "waiters / total statusErr={{ statusErr }}",
+              "refId": "B"
+            },
+            {
+              "expr": "kos_subnet_validator_validation_delay_due_to_downtime_seconds_sum / kos_subnet_validator_validation_delay_due_to_downtime_seconds_count",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "avg wait secs statusErr={{ statusErr }}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Subnet Validation Delay due to Validator Downtime",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 8
+            "y": 16
           },
           "id": 2,
           "legend": {
@@ -4573,13 +4673,114 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
+          "description": "The absolute number of attachments that were affected is scaled down by 100 to make it closer to the other plots and make sure the real values are not approximated.",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 23
+          },
+          "id": 17,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "kos_ipam_address_delay_due_to_downtime_seconds_count / 100",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "num waiters / 100 last_client_wr={{ last_client_wr }} last_controller_start={{ last_controller_start }}",
+              "refId": "A"
+            },
+            {
+              "expr": "kos_ipam_address_delay_due_to_downtime_seconds_count / scalar(sum(kos_ipam_last_client_write_to_address_latency_seconds_count))",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "waiters / total last_client_wr={{ last_client_wr }} last_controller_start={{ last_controller_start }}",
+              "refId": "B"
+            },
+            {
+              "expr": "kos_ipam_address_delay_due_to_downtime_seconds_sum / kos_ipam_address_delay_due_to_downtime_seconds_count",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "avg delay secs last_client_wr={{ last_client_wr }} last_controller_start={{ last_controller_start }}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Address Assignment Delay due to Controllers Downtime",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
           "description": "Fraction of attempt to allocate an address that fail because none is available",
           "fill": 1,
           "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 15
+            "y": 30
           },
           "id": 12,
           "legend": {
@@ -4664,7 +4865,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 22
+            "y": 37
           },
           "id": 1,
           "legend": {
@@ -4745,12 +4946,113 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
+          "description": "The absolute number of attachments that were affected is scaled down by 100 to make it closer to the other plots and make sure the real values are not approximated.",
           "fill": 1,
           "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 29
+            "y": 44
+          },
+          "id": 18,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "kos_agent_local_ifc_delay_due_to_downtime_seconds_count / 100",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "num waiters / 100 {{ node_name }} last_client_wr={{ last_client_wr }}",
+              "refId": "A"
+            },
+            {
+              "expr": "kos_agent_local_ifc_delay_due_to_downtime_seconds_count / on(node_name) group_left sum(kos_agent_last_client_write_to_local_ifc_latency_seconds_count) by (node_name)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "waiters / total {{ node_name }} last_client_wr={{ last_client_wr }}",
+              "refId": "B"
+            },
+            {
+              "expr": "kos_agent_local_ifc_delay_due_to_downtime_seconds_count / kos_agent_local_ifc_delay_due_to_downtime_seconds_sum",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "avg delay secs {{ node_name }} last_client_wr={{ last_client_wr }}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Local Interface Creation Delay due to CA Downtime",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 51
           },
           "id": 4,
           "legend": {
@@ -4835,7 +5137,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 36
+            "y": 58
           },
           "id": 13,
           "legend": {
@@ -4915,12 +5217,112 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
+          "description": "The absolute number of attachments that were affected is scaled down by 100 to make it closer to the other plots and make sure the real values are not approximated.",
           "fill": 1,
           "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 43
+            "y": 65
+          },
+          "id": 19,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "kos_agent_remote_ifc_delay_due_to_downtime_seconds_count / 100",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "num waiters / 100 {{ node_name }} last_ca_start={{ last_ca_start }} last_client_wr={{ last_client_wr }}",
+              "refId": "A"
+            },
+            {
+              "expr": "kos_agent_remote_ifc_delay_due_to_downtime_seconds_count / on(node_name) group_left sum(kos_agent_last_client_write_to_remote_ifc_latency_seconds_count) by (node_name)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "waiters / total {{ node_name }} last_ca_start={{ last_ca_start }} last_client_wr={{ last_client_wr }}",
+              "refId": "B"
+            },
+            {
+              "expr": "kos_agent_remote_ifc_delay_due_to_downtime_seconds_sum / kos_agent_remote_ifc_delay_due_to_downtime_seconds_count",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "avg delay secs {{ node_name }} last_ca_start={{ last_ca_start }} last_client_wr={{ last_client_wr }}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Remote Interface Creation Delay due to local or remote CA Downtime",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 72
           },
           "id": 14,
           "legend": {
@@ -5006,7 +5408,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 50
+            "y": 79
           },
           "id": 15,
           "legend": {
@@ -5091,7 +5493,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 57
+            "y": 86
           },
           "id": 9,
           "legend": {
@@ -5176,7 +5578,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 64
+            "y": 93
           },
           "id": 8,
           "legend": {
@@ -5261,7 +5663,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 71
+            "y": 100
           },
           "id": 7,
           "legend": {


### PR DESCRIPTION
Add dashboards to display the Prometheus metrics added by https://github.com/MikeSpreitzer/kube-examples/pull/119.

For every "implementation action" (e.g. address assignment, local network interface creation, etc...) and `(last_client_write, last_controller_start)` pair, there's a plot with:
1. Absolute number of actions that suffered a delay.
2. Fraction of delayed actions wrt total actions.
3. Average delay seconds.

The new plots are based on Prometheus histograms but do not use PromQL's `rate()` function to allow lazy materialization of metrics.